### PR TITLE
Avoid passing an undefined fn to fix CSP violations

### DIFF
--- a/src/utils/info-addon.js
+++ b/src/utils/info-addon.js
@@ -48,9 +48,6 @@ function onMouseOver(cm, e) {
 
   const box = target.getBoundingClientRect();
 
-  const hoverTime = getHoverTime(cm);
-  state.hoverTimeout = setTimeout(onHover, hoverTime);
-
   const onMouseMove = function() {
     clearTimeout(state.hoverTimeout);
     state.hoverTimeout = setTimeout(onHover, hoverTime);
@@ -69,6 +66,9 @@ function onMouseOver(cm, e) {
     state.hoverTimeout = undefined;
     onMouseHover(cm, box);
   };
+  
+  const hoverTime = getHoverTime(cm);
+  state.hoverTimeout = setTimeout(onHover, hoverTime);
 
   CodeMirror.on(document, 'mousemove', onMouseMove);
   CodeMirror.on(cm.getWrapperElement(), 'mouseout', onMouseOut);


### PR DESCRIPTION
This PR fixes a [Content Security Policy (CSP) violation](https://www.html5rocks.com/en/tutorials/security/content-security-policy/)  for those who are using CSP headers and do not have `script-src` of `unsafe-eval` enabled.

The way the code is written now, `onHover` is `undefined` in [this call to `setTimeout`](https://github.com/graphql/codemirror-graphql/blob/master/src/utils/info-addon.js#L52). Passing `undefined` to `setTimeout` triggers a CSP violation for `'unsafe-eval'` because `setTimeout` thinks you are passing a string, which is [not allowed](https://developer.chrome.com/extensions/contentSecurityPolicy#JSEval).

The CSP Violation: `Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: ...`

This PR moves the usage of `onHover` to after the function is defined, so that `setTimeout` is not called with `undefined` and there are no CSP violations.